### PR TITLE
90% Plat 2270 npm audit fix

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash'),
     request = require('request'),
-    md5 = require('MD5'),
+    md5 = require('md5'),
     querystring = require('querystring');
 
 // log severities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -14,27 +14,28 @@
   },
   "dependencies": {
     "cache-service": "1.3.5",
-    "cache-service-node-cache": "1.1.1",
+    "cache-service-node-cache": "2.0.0",
     "cache-service-redis": "2.0.0",
     "crypto-js": "3.1.2-2",
     "jsonwebtoken": "5.7.0",
-    "lodash": "3.10.1",
-    "uuid": "2.0.2",
-    "request": "^2.1.0",
-    "MD5": "^1.2.1"
+    "lodash": "4.17.11",
+    "md5": "2.2.1",
+    "node-cache": "4.2.0",
+    "request": "2.88.0",
+    "uuid": "2.0.2"
   },
   "devDependencies": {
     "debug": "2.6.8",
-    "js-beautify": "^1.8.9",
-    "jshint": "^2.10.1",
+    "js-beautify": "1.8.9",
+    "jshint": "2.10.1",
     "leche": "2.2.3",
     "mocha": "5.2.0",
     "nock": "7.2.2",
-    "nyc": "^13.1.0",
-    "proxyquire": "^2.1.0",
+    "nyc": "13.3.0",
+    "proxyquire": "2.1.0",
+    "rewire": "2.1.4",
     "should": "13.2.3",
-    "sinon": "3.0.0",
-    "rewire": "^2.1.4"
+    "sinon": "3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes all known vulnerabilities using `npm audit fix`. I have also pinned all version numbers because we can't use a `package-lock` here since we don't know the node version being used by the consumer.