### PR TITLE
Fixing addEvents bug

### DIFF
--- a/echo/index.js
+++ b/echo/index.js
@@ -213,7 +213,6 @@ function Client() {
         callback(errorResponse);
         return;
       } else {
-        delete body.statusCode;
         callback(null, {"code": codesAndLabels.SUCCESS, "label": codesAndLabels[codesAndLabels.SUCCESS], body: body});
       }
     });


### PR DESCRIPTION
At the end of the `addEvents` function it attempts to delete `statusCode` from `body`, but `body` is always undefined as the API call it's making to echo never returns anything, so this line of code isn't needed and it throws an error when it's run.