### PR TITLE
ELE-3028: Add new key to validation for babel

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -333,7 +333,8 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
         }
         for (var prop in target) {
             if(target.hasOwnProperty(prop)){
-                if (!(prop==="uri" || prop==="fragment" || prop==="asReferencedBy" || prop === "type" )) {
+                const validProps = ["uri", "fragment", "asReferencedBy", "type"];
+                if (validProps.indexOf(prop) === -1) {
                     throw new Error("Invalid data: hasTarget has unrecognised property '"+prop+"'");
                 }
             }

--- a/babel/index.js
+++ b/babel/index.js
@@ -333,7 +333,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
         }
         for (var prop in target) {
             if(target.hasOwnProperty(prop)){
-                if (!(prop==="uri" || prop==="fragment" || prop==="asReferencedBy" )) {
+                if (!(prop==="uri" || prop==="fragment" || prop==="asReferencedBy" || prop === "type" )) {
                     throw new Error("Invalid data: hasTarget has unrecognised property '"+prop+"'");
                 }
             }

--- a/babel/test/unit/babel_client_test.js
+++ b/babel/test/unit/babel_client_test.js
@@ -615,7 +615,8 @@ describe("Babel Node Client Test Suite", function(){
                     "annotatedBy": "bp",
                     "hasTarget": {
                         "fragment": "p=1",
-                        "uri": "my/uri"
+                        "uri": "my/uri",
+                        "type": 'Text'
                     },
                     "_id": "5628b931a394fb449e000247",
                     "annotatedAt": "2015-10-22T10:23:45.154Z",
@@ -1019,7 +1020,8 @@ describe("Babel Node Client Test Suite", function(){
                     annotatedAt: '2015-02-03T10:28:37.725Z',
                     motivatedBy: 'The Combine',
                     hasTarget: {
-                        uri: 'http://example.com/uri'
+                        uri: 'http://example.com/uri',
+                        type: 'Text'
                     },
                     hasBody:{
                         format: 'text/plain',
@@ -1036,12 +1038,13 @@ describe("Babel Node Client Test Suite", function(){
 
             babel.__set__("request", requestMock);
 
-            babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, {}, function(err, result){
+            babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com', type: 'Text'}, annotatedBy:'Gordon Freeman'}, {}, function(err, result){
 
                 (err === null).should.be.true;
 
                 result.annotatedBy.should.equal('Gordon Freeman');
                 result.hasTarget.uri.should.equal('http://example.com/uri');
+                result.hasTarget.type.should.equal('Text');
                 result.hasBody.uri.should.equal('http://example.com/another/uri');
                 done();
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-node",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We need the `type` key to figure out if an annotation is a text or non text annotation without having to parse the fragment.
This change is inline with the Open Annotation Data Model and should be released before the related elevate and babel changes
This is needed for https://github.com/talis/elevate-app/issues/3028