### PR TITLE
ELE-3337 Add support for new comment count path in Babel

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -143,6 +143,36 @@ BabelClient.prototype.getTargetFeed = function getTargetFeed(target, token, hydr
     });
 };
 
+BabelClient.prototype.getTargetFeedLength = function getTargetFeedLength(target, token, callback){
+    if(!target){
+        throw new Error('Missing target');
+    }
+    if(!token){
+        throw new Error('Missing Persona token');
+    }
+
+    var self = this;
+    var requestOptions = {
+        url: this._getBaseURL() +
+          '/feeds/targets/'+md5(target)+'/activity/annotations/aggregations/count',
+        headers: {
+            'Accept': 'application/json',
+            'Authorization':'Bearer '+token,
+            'Host': this.config.babel_hostname
+        }
+    };
+
+    this.debug(JSON.stringify(requestOptions));
+
+    request(requestOptions, function requestResponse(err, response, body){
+        if(err){
+            callback(err);
+        } else{
+            self._parseJSON(response, body, callback);
+        }
+    });
+};
+
 /***
  * Queries multiple feeds.
  * Given an array of feed ids it will return a merged hydrated feed.


### PR DESCRIPTION
In https://github.com/talis/babel-server/pull/202 a new route is being added so we can retrieve a count of the total number of comments for a particular target without needing to hydrate them.

This PR adds in a new method to the Talis node client to call that route.

The tests for this are based on the existing tests for `getTargetFeed` since the functionality and usage (from the consumer's perspective) is quite similar.