### PR TITLE
PLAT-3565 added local dev docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,8 @@ RUN apt-get update && apt-get install -y --force-yes \
         build-essential \
         envconsul \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-
-
-# Tidy up
-RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \
+    && apt-get clean \
+    && apt-get -y autoremove && apt-get clean && apt-get autoclean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir -p /var/talis-node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM talis/ubuntu:1404-latest
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --force-yes \
+        curl \
+        git \
+        apt-transport-https \
+        nodejs=8.9.4-1nodesource1 \
+        python \
+        build-essential \
+        envconsul \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+
+# Tidy up
+RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /var/talis-node
+COPY . /var/talis-node
+
+WORKDIR /var/talis-node
+
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ This is a development version of the new talis-node version. It is not yet inten
 Before releasing for general usage there will be major changes to the API. The library will move away from the use of internal Talis project names like Persona, Babel and Echo etc. Instead it will use more externally relavant names like ListReviews and Files. The API will also move to a more domain driven design rather than the service driven design of the individual libraries
 
 See issue: https://github.com/talis/talis-node/issues/2 and Milestone: https://github.com/talis/talis-node/milestone/1
+
+# Development Environment
+
+See: https://github.com/talis/talis-node/wiki/Local-Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    restart: always
+    networks:
+      - default
+  talis_node_dev:
+    image: talis/talis-node
+    links:
+      - redis
+    volumes:
+      - ".:/var/talis-node"
+    command: "/bin/bash"
+    environment:
+      REDIS_TEST_HOST: "redis"
+      REDIS_TEST_PORT: 6379
+    networks:
+      - default
+
+

--- a/persona/test/integration/persona_client.js
+++ b/persona/test/integration/persona_client.js
@@ -33,8 +33,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                         module: "redis",
                         options: {
                             redisData: {
-                                hostname: "localhost",
-                                port: 6379
+                                hostname: process.env.REDIS_TEST_HOST || "localhost",
+                                port: process.env.REDIS_TEST_PORT || 6379
                             }
                         }
                     }
@@ -98,8 +98,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                     module: "redis",
                     options: {
                         redisData: {
-                            hostname: "localhost",
-                            port: 6379
+                            hostname: process.env.REDIS_TEST_HOST || "localhost",
+                            port: process.env.REDIS_TEST_PORT || 6379
                         }
                     }
                 },
@@ -111,8 +111,8 @@ describe("Persona Client Test Suite - Constructor & Token Tests", function() {
                 persona_port: process.env.PERSONA_TEST_PORT || 80,
                 persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
                 persona_oauth_route: "/oauth/tokens/",
-                redis_host: "localhost",
-                redis_port: 6379,
+                redis_host: process.env.REDIS_TEST_HOST || "localhost",
+                redis_port: process.env.REDIS_TEST_PORT || 6379,
                 redis_db: 0,
                 enable_debug: false,
                 cert_background_refresh: false,

--- a/persona/test/integration/token_validation.js
+++ b/persona/test/integration/token_validation.js
@@ -39,8 +39,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
                 module: "redis",
                 options: {
                     redisData: {
-                        hostname: "localhost",
-                        port: 6379,
+                        hostname: process.env.REDIS_TEST_HOST || "localhost",
+                        port: process.env.REDIS_TEST_PORT || 6379,
                         detect_buffers: true,
                         return_buffers: true
                     }
@@ -54,8 +54,8 @@ describe("Persona Client Test Suite - Token Validation Tests", function() {
             persona_port: process.env.PERSONA_TEST_PORT || 80,
             persona_scheme: process.env.PERSONA_TEST_SCHEME || "http",
             persona_oauth_route: "/oauth/tokens/",
-            redis_host: "localhost",
-            redis_port: 6379,
+            redis_host: process.env.REDIS_TEST_HOST || "localhost",
+            redis_port: process.env.REDIS_TEST_PORT || 6379,
             redis_db: 0,
             enable_debug: false,
             cert_background_refresh: false,


### PR DESCRIPTION
### this relates to talis/platform#3565

- [x] Add a Dockerfile that will build a local image for development
- [x] Add a Docker Compose file to launch a redis service and run the local development image
- [x] Update Unit / Integration tests with hardcoded redis connection details to optionally override with env vars.
- [x] add wiki page: https://github.com/talis/talis-node/wiki/Local-Development