### PR TITLE
ELE-4109: Uncaught Babel client error when Babel 502s

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -453,16 +453,14 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
     this.debug(JSON.stringify(requestOptions));
 
     request.post(requestOptions, function requestResponse(err, response, body){
-        if(err){
+        if (err) {
             callback(err);
-        } else{
-            if(!this._responseSuccessful(response) || (body.message && body.errors)){
-                var babelError = new Error(body.message);
-                babelError.http_code = response.statusCode || 404;
-                callback(babelError);
-            } else{
-                callback(null, body);
-            }
+        } else if (!this._responseSuccessful(response)) {
+            var babelError = new Error('Error creating annotation: ' + JSON.stringify(body));
+            babelError.http_code = response && response.statusCode ? response.statusCode : 404;
+            callback(babelError);
+        } else {
+            callback(null, body);
         }
     }.bind(this));
 };
@@ -553,14 +551,12 @@ BabelClient.prototype.updateAnnotation = function updateAnnotation(token, data, 
     request.put(requestOptions, function requestResponse(err, response, body){
         if (err) {
             callback(err);
+        } else if (!this._responseSuccessful(response)) {
+            var babelError = new Error('Error updating annotation: ' + JSON.stringify(body));
+            babelError.http_code = response && response.statusCode ? response.statusCode : 404;
+            callback(babelError);
         } else {
-            if(!this._responseSuccessful(response) || (body.message && body.errors)){
-                var babelError = new Error(body.message);
-                babelError.http_code = response.statusCode || 404;
-                callback(babelError);
-            } else {
-                callback(null, body);
-            }
+            callback(null, body);
         }
     }.bind(this));
 };

--- a/babel/index.js
+++ b/babel/index.js
@@ -139,17 +139,17 @@ BabelClient.prototype.getEntireTargetFeed = async function (target, token, hydra
         this.debug(JSON.stringify(requestOptions));
 
         try {
-            const { 
+            const {
                 body: {
                     feed_length,
                     annotations,
                     userProfiles,
                     error,
                     error_description,
-                }, 
+                },
                 ...response
             } = await rpn(requestOptions);
-            
+
             if (error) {
                 callbackError = new Error(error_description);
                 callbackError.http_code = response.statusCode || 404;
@@ -267,7 +267,7 @@ BabelClient.prototype.getFeeds = function getFeeds(feeds, token, callback) {
 
     this.debug(JSON.stringify(requestOptions));
 
-    request(requestOptions, function requesResponse(err, response, body) {
+    request(requestOptions, function requestResponse(err, response, body) {
         if (err) {
             callback(err);
         } else {
@@ -364,7 +364,7 @@ BabelClient.prototype.getAnnotations = function getAnnotations(token, querystrin
  *
  * @param {string} token Persona token
  * @param {object} data Data that can be passed into an annotation
- * @param {object} data.hasbody
+ * @param {object} data.hasBody
  * @param {string} data.hasBody.format
  * @param {string} data.hasBody.type
  * @param {string} data.hasBody.chars
@@ -376,7 +376,7 @@ BabelClient.prototype.getAnnotations = function getAnnotations(token, querystrin
  * @param {string} data.hasTarget.fragment
  * @param {string} data.hasTarget.asReferencedBy
  * @param {string} data.annotatedBy
- * @param {string} data.motiviatedBy
+ * @param {string} data.motivatedBy
  * @param {string} data.annotatedAt
  * @param {object} options that control the request being made to babel.
  * @param {boolean} options.headers['X-Ingest-Synchronously']
@@ -471,7 +471,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
  * @param {string} token Persona token
  * @param {object} data Data that can be passed into an annotation
  * @param {object} data._id
- * @param {object} data.hasbody
+ * @param {object} data.hasBody
  * @param {string} data.hasBody.format
  * @param {string} data.hasBody.type
  * @param {string} data.hasBody.chars
@@ -483,7 +483,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
  * @param {string} data.hasTarget.fragment
  * @param {string} data.hasTarget.asReferencedBy
  * @param {string} data.annotatedBy
- * @param {string} data.motiviatedBy
+ * @param {string} data.motivatedBy
  * @param {string} data.annotatedAt
  * @param callback
  */

--- a/babel/test/unit/babel_client_test.js
+++ b/babel/test/unit/babel_client_test.js
@@ -206,7 +206,7 @@ describe("Babel Node Client Test Suite", function(){
                 babel_host:"http://babel",
                 babel_port:3000
             });
-            var requestStub = () => new Promise ((_resolve, reject) => reject(Error('Error communicating with Babel'))) 
+            var requestStub = () => new Promise ((_resolve, reject) => reject(Error('Error communicating with Babel')))
 
             babel.__set__("rpn", requestStub);
 
@@ -227,10 +227,10 @@ describe("Babel Node Client Test Suite", function(){
             var requestStub = () => new Promise ((resolve, reject) => resolve({
                 statusCode: 401,
                 body: {
-                    error:"invalid_token", 
+                    error:"invalid_token",
                     error_description:"The token is invalid or has expired"
                 }
-            })) 
+            }))
 
             babel.__set__("rpn", requestStub);
 
@@ -252,10 +252,10 @@ describe("Babel Node Client Test Suite", function(){
             var requestStub = () => new Promise ((resolve, _reject) => resolve({
                 statusCode: 404,
                 body: {
-                    error:"feed_not_found", 
+                    error:"feed_not_found",
                     error_description:"Feed not found"
                 }
-            })) 
+            }))
 
             babel.__set__("rpn", requestStub);
 
@@ -313,7 +313,7 @@ describe("Babel Node Client Test Suite", function(){
                         annotations
                     }
                 })
-            }) 
+            })
 
             var requestStubSpy = sinon.spy(requestStub);
             babel.__set__("rpn", requestStubSpy);
@@ -1155,10 +1155,46 @@ describe("Babel Node Client Test Suite", function(){
             babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, {}, function(err, result){
 
                 (err === null).should.be.false;
-                err.message.should.equal('Bad Request');
+                err.message.should.equal(
+                  'Error creating annotation: {"body":"","message":"Bad Request"}'
+                );
                 (typeof result).should.equal('undefined');
                 done();
             });
+        });
+
+        it("- should return an error if call to request returns a 502 response with no body", function (done) {
+          var babel = rewire("../../index.js");
+
+          var babelClient = babel.createClient({
+            babel_host: "http://babel",
+            babel_port: 3000,
+          });
+          var requestStub = {
+            post: function (options, callback) {
+              callback(null, { statusCode: 502 }, { message: "Bad Gateway" });
+            },
+          };
+
+          babel.__set__("request", requestStub);
+
+          babelClient.createAnnotation(
+            "secret",
+            {
+              hasBody: { format: "text/plain", type: "Text" },
+              hasTarget: { uri: "http://example.com" },
+              annotatedBy: "Gordon Freeman",
+            },
+            {},
+            function (err, result) {
+              (err === null).should.be.false;
+              err.message.should.equal(
+                'Error creating annotation: {"message":"Bad Gateway"}'
+              );
+              (typeof result).should.equal("undefined");
+              done();
+            }
+          );
         });
 
         it("- should return no errors if everything is successful", function(done){
@@ -1512,10 +1548,46 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.updateAnnotation('secret', {_id: 'testid', hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, function(err, result){
                 (err === null).should.be.false;
-                err.message.should.equal('Bad Request');
+                err.message.should.equal(
+                  'Error updating annotation: {"body":"","message":"Bad Request"}'
+                );
                 (typeof result).should.equal('undefined');
                 done();
             });
+        });
+
+        it("- should return an error if call to request returns a 502 response with no body", function (done) {
+          var babel = rewire("../../index.js");
+
+          var babelClient = babel.createClient({
+            babel_host: "http://babel",
+            babel_port: 3000,
+          });
+          var requestStub = {
+            put: function (options, callback) {
+              callback(null, { statusCode: 400 }, { message: "Bad Gateway" });
+            },
+          };
+
+          babel.__set__("request", requestStub);
+
+          babelClient.updateAnnotation(
+            "secret",
+            {
+              _id: "testid",
+              hasBody: { format: "text/plain", type: "Text" },
+              hasTarget: { uri: "http://example.com" },
+              annotatedBy: "Gordon Freeman",
+            },
+            function (err, result) {
+              (err === null).should.be.false;
+              err.message.should.equal(
+                'Error updating annotation: {"message":"Bad Gateway"}'
+              );
+              (typeof result).should.equal("undefined");
+              done();
+            }
+          );
         });
 
         it("- should return no errors if everything is successful", function(done){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-node",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/talis/elevate-app/issues/4109

Elevate has been seeing sporadic 502 Bad Gateway errors that seem to be caused by an uncaught exception in Node originating from the Babel node client

```
Feb  9 16:31:07 ip-10-227-17-204 2021-02-09T16:31:07+00:00 - error: uncaughtException: Cannot read property 'message' of undefined {"date":"Tue Feb 09 2021 16:31:07 GMT+0000 (Coordinated Universal Time)","process":{"pid":11678,"uid":0,"gid":0,"cwd":"/","execPath":"/usr/bin/node","version":"v10.14.2","argv":["/usr/bin/node","/mnt/tdc/live/server/talis-webserver.js","3000"],"memoryUsage":{"rss":269078528,"heapTotal":239136768,"heapUsed":144383600,"external":23319259}},"os":{"loadavg":[0.21337890625,0.294921875,0.31396484375],"uptime":1302586},"trace":[{"column":49,"file":"/mnt/tdc/a852380/node_modules/talis-node/babel/index.js","function":"babelClient.requestResponse","line":558,"method":"requestResponse","native":false},{"column":22,"file":"/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js","function":"Request.self.callback","line":185,"method":"callback","native":false},{"column":13,"file":"events.js","function":"Request.emit","line":182,"method":"emit","native":false},{"column":20,"file":"domain.js","function":"Request.EventEmitter.emit","line":441,"method":"emit","native":false},{"column":10,"file":"/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js","function":null,"line":1161,"method":null,"native":false},{"column":13,"file":"events.js","function":"Request.emit","line":182,"method":"emit","native":false},{"column":20,"file":"domain.js","function":"Request.EventEmitter.emit","line":441,"method":"emit","native":false},{"column":12,"file":"/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js","function":null,"line":1083,"method":null,"native":false},{"column":13,"file":"events.js","function":"Object.onceWrapper","line":273,"method":"onceWrapper","native":false},{"column":15,"file":"events.js","function":"IncomingMessage.emit","line":187,"method":"emit","native":false},{"column":20,"file":"domain.js","function":"IncomingMessage.EventEmitter.emit","line":441,"method":"emit","native":false},{"column":22,"file":"/mnt/tdc/a852380/node_modules/newrelic/lib/transaction/tracer/index.js","function":"IncomingMessage.wrapped","line":188,"method":"wrapped","native":false},{"column":24,"file":"/mnt/tdc/a852380/node_modules/newrelic/lib/instrumentation/core/http-outbound.js","function":"IncomingMessage.wrappedResponseEmit","line":215,"method":"wrappedResponseEmit","native":false},{"column":12,"file":"_stream_readable.js","function":"endReadableNT","line":1094,"method":null,"native":false},{"column":19,"file":"internal/process/next_tick.js","function":"process._tickCallback","line":63,"method":"_tickCallback","native":false}],"stack":["TypeError: Cannot read property 'message' of undefined","    at babelClient.requestResponse (/mnt/tdc/a852380/node_modules/talis-node/babel/index.js:558:49)","    at Request.self.callback (/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js:185:22)","    at Request.emit (events.js:182:13)","    at Request.EventEmitter.emit (domain.js:441:20)","    at Request.<anonymous> (/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js:1161:10)","    at Request.emit (events.js:182:13)","    at Request.EventEmitter.emit (domain.js:441:20)","    at IncomingMessage.<anonymous> (/mnt/tdc/a852380/node_modules/talis-node/node_modules/request/request.js:1083:12)","    at Object.onceWrapper (events.js:273:13)","    at IncomingMessage.emit (events.js:187:15)","    at IncomingMessage.EventEmitter.emit (domain.js:441:20)","    at IncomingMessage.wrapped (/mnt/tdc/a852380/node_modules/newrelic/lib/transaction/tracer/index.js:188:22)","    at IncomingMessage.wrappedResponseEmit (/mnt/tdc/a852380/node_modules/newrelic/lib/instrumentation/core/http-outbound.js:215:24)","    at endReadableNT (_stream_readable.js:1094:12)","    at process._tickCallback (internal/process/next_tick.js:63:19)"]}
```

The Babel client error handler is assuming we will always receive a `body` in request responses, but this does not happen if Babel returns a 502 Bad Gateway. 

This PR simplifies the error handling to not rely on `body` or `body.message` being defined