### PR TITLE
Bump package.json version to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-node",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
package.json got out of sync with our release tags when https://github.com/talis/talis-node/releases/tag/v0.1.7 was created. This bumps the version so we can get them back in sync.