### PR TITLE
ELE-6471 Round timestamps if they exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 package-lock.json
 .vscode
+.DS_Store

--- a/babel/test/unit/babel_client_test.js
+++ b/babel/test/unit/babel_client_test.js
@@ -145,7 +145,7 @@ describe("Babel Node Client Test Suite", function(){
             babel.__set__("request", requestStub);
 
             babelClient.headTargetFeed('TARGET', 'secret', function(err, response){
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 response.headers.should.have.property('x-feed-new-items', '1');
                 done();
             });
@@ -165,7 +165,7 @@ describe("Babel Node Client Test Suite", function(){
             babel.__set__("request", requestStub);
 
             babelClient.headTargetFeed('TARGET', 'secret', {}, function(err, response){
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 response.headers.should.have.property('x-feed-new-items', '2');
                 done();
             });
@@ -320,7 +320,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.getEntireTargetFeed('TARGET', 'secret', true, function(err, result){
                 requestStubSpy.callCount.should.equal(2);
-                (err === undefined).should.be.true;
+                (err === undefined).should.be.true();
                 result.feed_length.should.equal(1002);
                 result.userProfiles.user_1.first_name.should.equal('TN')
                 result.annotations.should.have.lengthOf(1002);
@@ -370,7 +370,7 @@ describe("Babel Node Client Test Suite", function(){
             babel.__set__("request", requestStub);
 
             babelClient.getTargetFeed('TARGET', 'secret', null, function(err){
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 done();
             });
         });
@@ -479,7 +479,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.getTargetFeed('TARGET', 'secret', {}, function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 result.count.should.equal(2);
                 result.limit.should.equal(25);
                 result.annotations.should.have.lengthOf(2);
@@ -659,7 +659,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.getFeeds(['FEED1', ['FEED2']], 'secret', function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 result.feed_length.should.equal(2);
                 result.limit.should.equal(25);
                 result.annotations.should.have.lengthOf(2);
@@ -794,7 +794,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.getAnnotation("secret", "5628b931a394fb449e000247", function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 result._id.should.equal("5628b931a394fb449e000247");
                 done();
             });
@@ -931,7 +931,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.getAnnotations('secret', {}, function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 result.count.should.equal(2);
                 result.limit.should.equal(25);
                 result.annotations.should.have.lengthOf(2);
@@ -1235,7 +1235,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com', type: 'Text'}, annotatedBy:'Gordon Freeman'}, {}, function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
 
                 result.annotatedBy.should.equal('Gordon Freeman');
                 result.hasTarget.uri.should.equal('http://example.com/uri');
@@ -1282,7 +1282,7 @@ describe("Babel Node Client Test Suite", function(){
 
             babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
 
                 result.annotatedBy.should.equal('Gordon Freeman');
                 result.hasTarget.uri.should.equal('http://example.com/uri');
@@ -1626,7 +1626,7 @@ describe("Babel Node Client Test Suite", function(){
             babel.__set__("request", requestMock);
 
             babelClient.updateAnnotation('secret', {_id: 'testid', hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com', type: 'Text'}, annotatedBy:'Gordon Freeman'}, function(err, result){
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 result.annotatedBy.should.equal('Gordon Freeman');
                 result.hasTarget.uri.should.equal('http://example.com/uri');
                 result.hasBody.uri.should.equal('http://example.com/another/uri');

--- a/echo/index.js
+++ b/echo/index.js
@@ -155,6 +155,12 @@ function Client() {
     });
   }
 
+  function roundTimestamp(event){
+    if (!event.timestamp || Number.isInteger(event.timestamp)) return event;
+    
+    return Object.assign({}, event, { timestamp: Math.round(event.timestamp) })
+  }
+
   /**
      * Add an event or events
      * @param {string} token
@@ -167,6 +173,7 @@ function Client() {
      * @callback callback
      */
   EchoClient.prototype.addEvents = function addEvents(token, data, callback) {
+    let eventData
     if (!token) {
       throw new Error('Missing Persona token');
     }
@@ -184,6 +191,10 @@ function Client() {
       if (!data.source) {
         throw new Error('Missing field data.source');
       }
+
+      eventData = roundTimestamp(data)
+    } else {
+      eventData = data.map(roundTimestamp)
     }
 
     var requestOptions = {
@@ -192,7 +203,7 @@ function Client() {
         Accept: 'application/json',
         Authorization: 'Bearer ' + token
       },
-      body: data,
+      body: eventData,
       method: 'POST',
       json: true
     };

--- a/echo/test/unit/echo_client_test.js
+++ b/echo/test/unit/echo_client_test.js
@@ -262,10 +262,42 @@ describe("Echo Node Client Test Suite", function(){
                 );
             });
 
-            const events = [{class:'class', source:'source', timestamp: 1324524508 }, {class:'class', source:'source', timestamp: 1324524509.123 }];
+            const events = [
+                {
+                    class:'class',
+                    source:'source',
+                    timestamp: 1324524508
+                },
+                {
+                    class:'class',
+                    source:'source', 
+                    timestamp: 1324524509.123
+                },
+                {
+                    class:'class',
+                    source:'source', 
+                    timestamp: 1324524509.623
+                },
+            ];
             
             echoClient.addEvents('secret', events, function(err){
-                const updatedEvents = [{class:'class', source:'source', timestamp: 1324524508 }, {class:'class', source:'source', timestamp: 1324524509 }];
+                const updatedEvents = [
+                    {
+                        class:'class',
+                        source:'source',
+                        timestamp: 1324524508
+                    },
+                    {
+                        class:'class',
+                        source:'source', 
+                        timestamp: 1324524509
+                    },
+                    {
+                        class:'class',
+                        source:'source', 
+                        timestamp: 1324524510
+                    },
+                ];
                 
                 (err === null).should.be.true;
                 

--- a/echo/test/unit/echo_client_test.js
+++ b/echo/test/unit/echo_client_test.js
@@ -229,7 +229,7 @@ describe("Echo Node Client Test Suite", function(){
 
             echoClient.addEvents('secret', {class:'class', source:'source'}, function(err, result){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
 
                 result.body.timestamp.should.equal(1324524509);
                 result.body.user.should.equal("1234-5678-9012-3456");
@@ -299,7 +299,7 @@ describe("Echo Node Client Test Suite", function(){
                     },
                 ];
                 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 
                 requestStub.callCount.should.equal(1);
                 const eventData = requestStub.firstCall.args[0].body;
@@ -332,7 +332,7 @@ describe("Echo Node Client Test Suite", function(){
 
             echoClient.addEvents('secret', {class:'class', source:'source', timestamp: 1324524509.123}, function(err){
 
-                (err === null).should.be.true;
+                (err === null).should.be.true();
 
                 requestStub.callCount.should.equal(1);
                 const eventData = requestStub.firstCall.args[0].body;
@@ -442,7 +442,7 @@ describe("Echo Node Client Test Suite", function(){
             var queryAnalytics = function(){
                 return echoClient.queryAnalytics('secret', 'sum', params, false, function(err, result){
                     var firstCall = requestStub.firstCall;
-                    (err === null).should.be.true;
+                    (err === null).should.be.true();
                     requestStub.callCount.should.equal(1);
                     firstCall.args[0].method.should.equal('GET');
                     firstCall.args[0].url.should.equal(endPoint + '/1/analytics/sum?class=testclass&source=testsources&property=testproperty&interval=testinterval&group_by=testgroupby&key=testkey&value=testvalue&from=testfrom&to=testto&percentile=testpercentile&user=testuser&user.include=includeuser&user.exclude=excludeuser&filter=testfilter&filter.test=testfilter&n=testn&n.something=something');
@@ -534,11 +534,11 @@ describe("Echo Node Client Test Suite", function(){
 
             echoClient.queryAnalytics('secret', 'sum', params, false, function(err, result){
                 var firstCall = requestStub.firstCall;
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 requestStub.callCount.should.equal(1);
                 firstCall.args[0].method.should.equal('GET');
                 firstCall.args[0].headers['cache-control'].should.equal('none');
-                (result.body.results instanceof Array).should.be.true;
+                (result.body.results instanceof Array).should.be.true();
                 result.body.results.length.should.equal(2);
                 result.body.results[0].user.should.equal('8av3Jaj__vC9v9VIY_P-1w');
                 result.body.head.class.should.equal(params.class);
@@ -574,11 +574,11 @@ describe("Echo Node Client Test Suite", function(){
 
             echoClient.queryAnalytics('secret', 'sum', params, true, function(err, result){
                 var firstCall = requestStub.firstCall;
-                (err === null).should.be.true;
+                (err === null).should.be.true();
                 requestStub.callCount.should.equal(1);
                 firstCall.args[0].method.should.equal('GET');
                 firstCall.args[0].headers.should.not.have.property('cache-control');
-                (result.body.results instanceof Array).should.be.true;
+                (result.body.results instanceof Array).should.be.true();
                 result.body.results.length.should.equal(2);
                 result.body.results[0].user.should.equal('8av3Jaj__vC9v9VIY_P-1w');
                 result.body.head.class.should.equal(params.class);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talis-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- talis/elevate-app#6471

There is a proposed change to the echo api to only accept integer timestamp values. We will try to ensure we only send interger values but to catch any events we might miss we're adding a step in the echo client (used by all the calls in elevate to echo) to round the timestamp to the nearest whole number.